### PR TITLE
[FEAT] updateBoard API 생성 (#23)

### DIFF
--- a/src/api/boards/boards.module.ts
+++ b/src/api/boards/boards.module.ts
@@ -2,6 +2,7 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CardInfosService } from '../cardInfos/cardInfos.service';
 import { CardInfo } from '../cardInfos/entities/cardInfo.entity';
+import { CategoriesService } from '../categories/categories.service';
 import { Category } from '../categories/entities/category.entity';
 import { Image } from '../images/entities/image.entity';
 import { Location } from '../locations/entities/location.entity';
@@ -28,6 +29,7 @@ import { Board } from './entities/board.entity';
     BoardsService,
     UsersService,
     CardInfosService,
+    CategoriesService,
   ],
 })
 export class BoardsModule {}

--- a/src/api/boards/boards.resolver.ts
+++ b/src/api/boards/boards.resolver.ts
@@ -5,6 +5,7 @@ import { IContext } from 'src/commons/types/type';
 
 import { BoardsService } from './boards.service';
 import { CreateBoardInput } from './dto/createBoard.input';
+import { updateBoardInput } from './dto/updateBoard.input';
 import { Board } from './entities/board.entity';
 
 @Resolver()
@@ -12,7 +13,7 @@ export class BoardsResolver {
   constructor(private readonly boardsService: BoardsService) {}
 
   @Query(() => [Board])
-  featchBoards() {
+  fetchBoards() {
     return this.boardsService.findAll();
   }
 
@@ -32,5 +33,13 @@ export class BoardsResolver {
     const user = context.req.user;
 
     return this.boardsService.create({ createBoardInput, email: user.email });
+  }
+  @UseGuards(GqlAuthAccessGuard)
+  @Mutation(() => Board)
+  async updateBoard(
+    @Args('boardId') boardId: string,
+    @Args('updateBoardInput') updateBoardInput: updateBoardInput,
+  ) {
+    return await this.boardsService.update({ boardId, updateBoardInput });
   }
 }

--- a/src/api/boards/dto/updateBoard.input.ts
+++ b/src/api/boards/dto/updateBoard.input.ts
@@ -1,0 +1,5 @@
+import { InputType, PartialType } from '@nestjs/graphql';
+import { CreateBoardInput } from './createBoard.input';
+
+@InputType()
+export class updateBoardInput extends PartialType(CreateBoardInput) {}

--- a/src/api/boards/entities/board.entity.ts
+++ b/src/api/boards/entities/board.entity.ts
@@ -55,10 +55,6 @@ export class Board {
   price: number;
 
   @Column()
-  @Field(() => Int)
-  productPrice: number;
-
-  @Column()
   @Field(() => String)
   storeName: string;
 

--- a/src/api/categories/categories.module.ts
+++ b/src/api/categories/categories.module.ts
@@ -1,8 +1,12 @@
 import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
 import { CategoriesResolver } from './categories.resolver';
 import { CategoriesService } from './categories.service';
+import { Category } from './entities/category.entity';
 
 @Module({
+  imports: [TypeOrmModule.forFeature([Category])],
+
   providers: [
     CategoriesResolver, //
     CategoriesService,

--- a/src/api/categories/categories.resolver.ts
+++ b/src/api/categories/categories.resolver.ts
@@ -1,4 +1,24 @@
-import { Resolver } from '@nestjs/graphql';
+import { Args, Mutation, Resolver, Query } from '@nestjs/graphql';
+import { CategoriesService } from './categories.service';
+import { Category } from './entities/category.entity';
 
 @Resolver()
-export class CategoriesResolver {}
+export class CategoriesResolver {
+  constructor(
+    private readonly categoriesService: CategoriesService, //
+  ) {}
+  @Query(() => [Category])
+  fetchCategories() {
+    return this.categoriesService.findAll();
+  }
+  //카테고리 생성
+  @Mutation(() => Category)
+  createCategory(
+    @Args('name') name: string, //
+  ) {
+    const newCategory = this.categoriesService.create({ name });
+
+    console.log(newCategory);
+    return newCategory;
+  }
+}

--- a/src/api/categories/categories.service.ts
+++ b/src/api/categories/categories.service.ts
@@ -1,4 +1,31 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Category } from './entities/category.entity';
 
 @Injectable()
-export class CategoriesService {}
+export class CategoriesService {
+  constructor(
+    @InjectRepository(Category)
+    private readonly categoryRepository: Repository<Category>,
+  ) {}
+
+  async create({ name }) {
+    const result = await this.categoryRepository.save({ name });
+
+    return result;
+  }
+
+  async findOne({ categoryName }) {
+    const selectCategory = await this.categoryRepository.findOne({
+      where: { name: categoryName },
+    });
+    return selectCategory;
+  }
+
+  async findAll() {
+    const resultCategorys = await this.categoryRepository.find({});
+    console.log(resultCategorys);
+    return resultCategorys;
+  }
+}

--- a/src/api/categories/entities/category.entity.ts
+++ b/src/api/categories/entities/category.entity.ts
@@ -8,7 +8,7 @@ export class Category {
   @Field(() => String)
   id: string;
 
-  @Column()
+  @Column({ unique: true })
   @Field(() => String)
   name: string;
 }

--- a/src/api/inquiries/inquiries.module.ts
+++ b/src/api/inquiries/inquiries.module.ts
@@ -4,6 +4,7 @@ import { BoardsService } from '../boards/boards.service';
 import { Board } from '../boards/entities/board.entity';
 import { CardInfosService } from '../cardInfos/cardInfos.service';
 import { CardInfo } from '../cardInfos/entities/cardInfo.entity';
+import { CategoriesService } from '../categories/categories.service';
 import { Category } from '../categories/entities/category.entity';
 import { Image } from '../images/entities/image.entity';
 import { Location } from '../locations/entities/location.entity';
@@ -31,6 +32,7 @@ import { InquiriesService } from './inquiries.service';
     UsersService,
     BoardsService,
     CardInfosService,
+    CategoriesService,
   ],
 })
 export class InquiriesModule {}

--- a/src/api/inquiriesAnswer/inquiriesAnswer.module.ts
+++ b/src/api/inquiriesAnswer/inquiriesAnswer.module.ts
@@ -4,6 +4,7 @@ import { BoardsService } from '../boards/boards.service';
 import { Board } from '../boards/entities/board.entity';
 import { CardInfosService } from '../cardInfos/cardInfos.service';
 import { CardInfo } from '../cardInfos/entities/cardInfo.entity';
+import { CategoriesService } from '../categories/categories.service';
 import { Category } from '../categories/entities/category.entity';
 import { Image } from '../images/entities/image.entity';
 import { Inquiry } from '../inquiries/entities/inquiry.entity';
@@ -35,6 +36,7 @@ import { InquiriesAnswerService } from './inquiriesAnswer.service';
     UsersService,
     BoardsService,
     CardInfosService,
+    CategoriesService,
   ],
 })
 export class InquiriesAnswerModule {}

--- a/src/api/interests/interests.module.ts
+++ b/src/api/interests/interests.module.ts
@@ -4,6 +4,7 @@ import { BoardsService } from '../boards/boards.service';
 import { Board } from '../boards/entities/board.entity';
 import { CardInfosService } from '../cardInfos/cardInfos.service';
 import { CardInfo } from '../cardInfos/entities/cardInfo.entity';
+import { CategoriesService } from '../categories/categories.service';
 import { Category } from '../categories/entities/category.entity';
 import { Image } from '../images/entities/image.entity';
 import { Location } from '../locations/entities/location.entity';
@@ -32,6 +33,7 @@ import { InterestsService } from './interests.service';
     UsersService,
     CardInfosService,
     BoardsService,
+    CategoriesService,
   ],
 })
 export class InterestsModule {}

--- a/src/api/runners/runners.module.ts
+++ b/src/api/runners/runners.module.ts
@@ -4,6 +4,7 @@ import { BoardsService } from '../boards/boards.service';
 import { Board } from '../boards/entities/board.entity';
 import { CardInfosService } from '../cardInfos/cardInfos.service';
 import { CardInfo } from '../cardInfos/entities/cardInfo.entity';
+import { CategoriesService } from '../categories/categories.service';
 import { Category } from '../categories/entities/category.entity';
 import { Image } from '../images/entities/image.entity';
 import { Location } from '../locations/entities/location.entity';
@@ -31,6 +32,7 @@ import { RunnersService } from './runners.service';
     BoardsService,
     UsersService,
     CardInfosService,
+    CategoriesService,
   ],
 })
 export class RunnersModule {}


### PR DESCRIPTION
board table
- updateBoard API 생성

* createBoard 할 때 category를 직접 만드는 것이 아닌 만들어진 category 목록에서 
데이터를 가져와서 만드는 것이 좋다고 판단.
* category에서 데이터를 가져오기 위해서는 category table 에서 직접 카테고리 id와 name을 지정해줘야함.

category table 

-fetchCategories API 생성

-createCategory API 생성
- categoriesService에서 categoryId 를 찾아오는 로직 생성

* 추가적으로 categoriesServices에 로직을 추가하니 category와 관련 있는 table의 모듈들에 전부 CategoriesService 를 providers로 지정해줘야했음.
