### PR TITLE
[FEAT] refreshes 폴더 생성 및 API 생성(#326)

### DIFF
--- a/src/api/boards/boards.module.ts
+++ b/src/api/boards/boards.module.ts
@@ -1,5 +1,6 @@
 import { Module } from '@nestjs/common';
 import { ElasticsearchModule } from '@nestjs/elasticsearch';
+import { ScheduleModule } from '@nestjs/schedule';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { BankAccountsService } from '../bankAccounts/bankAccounts.service';
 import { BankAccount } from '../bankAccounts/entities/ bankAccount.entity';

--- a/src/api/boards/boards.service.ts
+++ b/src/api/boards/boards.service.ts
@@ -1,4 +1,8 @@
-import { Injectable, NotFoundException } from '@nestjs/common';
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { DataSource, Like, MoreThan, Repository } from 'typeorm';
 import { Image } from '../images/entities/image.entity';
@@ -84,6 +88,10 @@ export class BoardsService {
       if (!createBoardInput.eventDay || !createBoardInput.eventTime) {
         dueDate = new Date('2023');
       }
+      // 행사 날짜 입력시  이미 지난 날짜를 입력 할 경우
+      // const today = new Date();
+      // if (dueDate < today)
+      //   throw new ConflictException('행사 날짜가 올바르지 않습니다.');
 
       let img;
 

--- a/src/api/boards/entities/board.entity.ts
+++ b/src/api/boards/entities/board.entity.ts
@@ -23,6 +23,7 @@ export enum BOARD_STATUS_ENUM {
   FINISHED = '완료',
   REPORTING = '신고진행중',
   COMPLETED = '처리완료',
+  ENDED = '일자마감',
 }
 
 registerEnumType(BOARD_STATUS_ENUM, {

--- a/src/api/refreshes/refreshes.module.ts
+++ b/src/api/refreshes/refreshes.module.ts
@@ -1,9 +1,20 @@
-// import { Module } from '@nestjs/common';
-// import { ScheduleModule } from '@nestjs/schedule';
-// import { RefreshesService } from './refreshes.service';
+import { Module } from '@nestjs/common';
+import { ScheduleModule } from '@nestjs/schedule';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Board } from '../boards/entities/board.entity';
+import { PaymentHistory } from '../paymentHistories/entities/paymentHistory.entity';
+import { User } from '../users/entities/user.entity';
+import { RefreshesService } from './refreshes.service';
 
-// @Module({
-//   imports: [ScheduleModule.forRoot()],
-//   providers: [RefreshesService],
-// })
-// export class RefreshesModule {}
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      Board, //
+      User,
+      PaymentHistory,
+    ]),
+    ScheduleModule.forRoot(),
+  ],
+  providers: [RefreshesService],
+})
+export class RefreshesModule {}

--- a/src/api/refreshes/refreshes.service.ts
+++ b/src/api/refreshes/refreshes.service.ts
@@ -1,42 +1,61 @@
-// import { Injectable } from '@nestjs/common';
-// import { Cron } from '@nestjs/schedule';
-// import { InjectRepository } from '@nestjs/typeorm';
-// import { Repository } from 'typeorm';
-// import { BoardsService } from '../boards/boards.service';
-// import { Board, BOARD_STATUS_ENUM } from '../boards/entities/board.entity';
-// import { PaymentHistory } from '../paymentHistories/entities/paymentHistory.entity';
-// import { User } from '../users/entities/user.entity';
+import { Injectable } from '@nestjs/common';
+import { Cron } from '@nestjs/schedule';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { BoardsService } from '../boards/boards.service';
+import { Board, BOARD_STATUS_ENUM } from '../boards/entities/board.entity';
+import { PaymentHistory } from '../paymentHistories/entities/paymentHistory.entity';
+import { User } from '../users/entities/user.entity';
 
-// @Injectable()
-// export class RefreshesService {
-//   constructor(
-//     @InjectRepository(Board)
-//     private readonly boardRepository: Repository<Board>,
-//     @InjectRepository(User)
-//     private readonly userRepository: Repository<User>,
-//     @InjectRepository(PaymentHistory)
-//     private readonly paymentHistory: Repository<PaymentHistory>,
-//   ) {}
+@Injectable()
+export class RefreshesService {
+  constructor(
+    @InjectRepository(Board)
+    private readonly boardRepository: Repository<Board>,
+    @InjectRepository(User)
+    private readonly userRepository: Repository<User>,
+    @InjectRepository(PaymentHistory)
+    private readonly paymentHistory: Repository<PaymentHistory>,
+  ) {}
 
-//   //   @Cron('* * * * * *')
-//   //   test() {
-//   //     console.log('Hola!');
-//   //   }
+  //   @Cron('* * * * * *')
+  //   test() {
+  //     console.log('Hola!');
+  //   }
 
-//   @Cron('* * * * *')
-//   async refreshBoard() {
-//     //
-//     const newBoard = await this.boardRepository.find({
-//       where: { status: BOARD_STATUS_ENUM.RECRUITING },
-//       relations: ['user'],
-//     });
-//     const today = new Date();
-//     for (let i = 0; i < newBoard.length; i++) {
-//       if (today < newBoard[i].dueDate) {
-//         //
-//         newBoard[i].status = ''; // status 하나 더 만들어주고
-//         // user 포인트 업데이트 시켜주기
-//       }
-//     }
-//   }
-// }
+  @Cron('* * * * *')
+  async refreshBoard() {
+    //
+    const newBoard = await this.boardRepository.find({
+      where: { status: BOARD_STATUS_ENUM.RECRUITING },
+      relations: ['user'],
+    });
+    const today = new Date();
+
+    for (let i = 0; i < newBoard.length; i++) {
+      if (today > newBoard[i].dueDate) {
+        //
+
+        this.boardRepository.update(
+          { id: newBoard[i].id },
+          { status: BOARD_STATUS_ENUM.ENDED },
+        );
+        // status 바꾸기
+        const result = await this.paymentHistory.save({
+          board: newBoard[i],
+          user: newBoard[i].user,
+          price: newBoard[i].price,
+          title: newBoard[i].title,
+          status: 'refund',
+        });
+        console.log(result);
+        this.userRepository.update(
+          { email: newBoard[i].user.email },
+          { point: newBoard[i].user.point + newBoard[i].price },
+        );
+        // user 포인트 업데이트 시켜주기
+      }
+      return newBoard;
+    }
+  }
+}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -22,7 +22,7 @@ import { FileModule } from './api/file/file.module';
 import { ChatModule } from './api/chat/chat.module';
 import { NotificationsModule } from './api/notifications/notifications.module';
 import { EventsModule } from './api/events/events.module';
-// import { RefreshesModule } from './api/refreshes/refreshes.module';
+import { RefreshesModule } from './api/refreshes/refreshes.module';
 
 @Module({
   imports: [
@@ -37,7 +37,7 @@ import { EventsModule } from './api/events/events.module';
     NotificationsModule,
     PaymentHistoriesModule,
     PaymentsModule,
-    // RefreshesModule,
+    RefreshesModule,
     ReportsModule,
     RunnersModule,
     TokensModule,


### PR DESCRIPTION
refreshes.service.ts 에서

dueDate 가 today 시간 넘어가게 될 경우 

1. board status 변경 및 신청금액 되돌려주기.
2. paymentHistory에 로그 status refund로 새로 저장.
3.  추가적으로 board에서 create 할 때 dueDate 를 이미 지난 날로 입력할 시 오류 생성